### PR TITLE
Function parsing

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -110,9 +110,11 @@ function getDefaultToken(
     return emitToken('COMMENT');
   }
 
-  // ******* THIS IS WHERE THE TEST FUNCTION IS *************
-  if (stream.match(/inverse\(/)) {
-    return emitToken('INVERSE');
+  // Identifiers
+  // For now, the form of a valid identifier is: an alphabetic character,
+  // followed by one or more alphanumeric characters.
+  if (stream.match(/([a-z|A-Z])+\w+/)) {
+    return emitToken('IDENTIFIER');
   }
 
   stream.next();
@@ -128,9 +130,6 @@ export type BinaryOperationTokenType =
   // NOTE: we are considering the "^" operation to be a strictly boolean operation
   //       it will represent an "or" operation
 
-export type FunctionTokenType = 
-  | 'INVERSE';
-
 export type TokenType =
   | BinaryOperationTokenType
   | 'NUMBER'
@@ -140,7 +139,7 @@ export type TokenType =
   | ')'
   | 'COMMENT'
   | 'ERROR'
-  | FunctionTokenType;
+  | 'IDENTIFIER'
 
 export interface Token<T extends TokenType = TokenType> {
   type: T;

--- a/src/mode.ts
+++ b/src/mode.ts
@@ -52,11 +52,8 @@ export function MakeMode(_config: CodeMirror.EditorConfiguration, _modeOptions?:
         case 'COMMENT':
           return 'comment';
 
-        case 'INVERSE':
-        case 'DEFTEST':
-        case 'DEFTRUE':
-        case 'DEFFALSE':
-          return 'function';
+        case 'IDENTIFIER':
+          return 'variable';
 
         case 'ERROR':
           return 'error';

--- a/src/parselet.ts
+++ b/src/parselet.ts
@@ -82,37 +82,22 @@ export class BinaryOperatorParselet extends ConsequentParselet {
   }
 }
 
-// ************** THIS IS WHERE THE FUNCTION PARSELET LIVES ******************
-/*
-type
-name: string;
-  arg: ArgumentNode;
-  outputType: MaybeUnd;
-  pos: Position;
-*/
+// Parse function calls
+// Limitation: Functions are allowed to take exactly one argument
 export class FunctionParselet implements InitialParselet {
-  constructor(private value: string) {}
   parse(parser: AbstractParser, tokens: TokenStream, token: Token) {
-    const input = parser.parse(tokens, 0);
+
+    tokens.expectToken('(');
+    const exp = parser.parse(tokens, 0);  // allow for one argument
     tokens.expectToken(')');
 
-    if (this.value == 'inverse') {
-      return {
-        nodeType: 'Function' as 'Function',
-        name: 'inverse',
-        arg: input,
-        outputType: { status: 'Maybe-Undefined' as 'Maybe-Undefined',
-                      value: 'number' as 'number' },
-        pos: token2pos(token)
-      }
+    return {
+      nodeType: 'Function' as 'Function',
+      name: token.text,
+      arg: exp,
+      outputType: { status: 'Maybe-Undefined' as 'Maybe-Undefined',
+                    value: 'number' as 'number' },
+      pos: token2pos(token)
     }
-
-    else {
-      throw new ParseError(
-        `Unknown function`,
-        token2pos(token),
-      );
-    }
-    
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -116,7 +116,7 @@ export class Parser extends AbstractParser {
       TRUE: new Parselet.BooleanParselet(true),
       FALSE: new Parselet.BooleanParselet(false),
       '(': new Parselet.ParenParselet(),
-      INVERSE: new Parselet.FunctionParselet('inverse'),
+      IDENTIFIER: new Parselet.FunctionParselet(),
     };
   }
 

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -80,28 +80,30 @@ class CheckBinary implements TypeChecker {
 class CheckFunction implements TypeChecker {
   check(node: AST.FunctionNode): TypeError[] {
     const errors: TypeError[] = [];
-    if (node.name == 'isDefined') {
-      // actually argument checking is unnecessary because the editor just doesn't recognize it
-      // if it has the wrong argument type yikes
-      // need to check that the argument is either a function or a boolean
-      if (node.arg.nodeType != "Function" && node.arg.nodeType != "Boolean") {
-        // then we have a problem
-        errors.push(new TypeError("incompatible argument type for isDefined", node.pos));
-      }
-      // maybe if it is a function we need to make sure that function is defined so we can
-      // convert it into Definitely, or maybe that takes place in the choose node
-    }
-    else if (node.name == 'test') {
-      // make sure there is no argument
-      if (node.arg != undefined) {
-        errors.push(new TypeError("the test function does not take an argument", node.pos));
+
+    const functionName = node.name
+    const argType = builtins[functionName];
+
+    // we found a builtin function
+    if (argType) {
+
+      // typecheck the argument
+      if (node.arg.nodeType != argType) {
+        errors.push(new TypeError("incompatible argument type for " + functionName, node.pos));
       }
     }
+  
+    // this is not a known, builtin function
     else {
-      // name is unknown
       errors.push(new TypeError("unknown function", node.pos));
     }
+
+    return errors;
   }
+}
+
+const builtins : {[name: string]: AST.NodeType} = {
+  "isDefined" : 'Boolean'
 }
 
 const checkerMap: Partial<{[K in AST.NodeType]: TypeChecker}> = {

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -102,6 +102,7 @@ class CheckFunction implements TypeChecker {
   }
 }
 
+// Dictionary of builtin functions that maps a function name to the type of its argument
 const builtins : {[name: string]: AST.NodeType} = {
   "isDefined" : 'Boolean'
 }


### PR DESCRIPTION
I made a few changes to the parser, to make it easier to parse functions:

1. The parser is more general; it doesn't hard-code function names. The parser can now parse any function call that takes exactly one argument. (If we need arbitrary number of arguments, we can add that in later.)
2. The typechecker hard-codes builtin function names, along with the types of each function's arguments. Right now, there is one builtin function called `isDefined`.